### PR TITLE
fix: ♻  ensure 'metadata' columns are stored as JSON

### DIFF
--- a/ggdp/assets.py
+++ b/ggdp/assets.py
@@ -1,3 +1,5 @@
+import json
+
 import pandas as pd
 from dagster import asset
 from fsspec.implementations.http import HTTPFileSystem
@@ -76,7 +78,9 @@ def raw_passport_scores() -> pd.DataFrame:
 
 @asset
 def raw_projects() -> pd.DataFrame:
-    return chain_file_aggregator("projects.json")
+    projects = chain_file_aggregator("projects.json")
+    projects['metadata'] = projects['metadata'].apply(json.dumps)
+    return projects
 
 
 @asset
@@ -86,7 +90,9 @@ def raw_prices() -> pd.DataFrame:
 
 @asset
 def raw_rounds() -> pd.DataFrame:
-    return chain_file_aggregator("rounds.json")
+    rounds = chain_file_aggregator("rounds.json")
+    rounds['metadata'] = rounds['metadata'].apply(json.dumps)
+    return rounds
 
 
 @asset
@@ -96,7 +102,9 @@ def raw_round_votes() -> pd.DataFrame:
 
 @asset
 def raw_round_applications() -> pd.DataFrame:
-    return round_file_aggregator("applications.json")
+    applications = chain_file_aggregator("applications.json")
+    applications['metadata'] = applications['metadata'].apply(json.dumps)
+    return applications
 
 
 @asset


### PR DESCRIPTION
Quick fix to ensure all `metadata` columns are stored as JSON strings, not as serialized python objects. Duplicate code would look nicer in shared function, but this should work as-is.