### PR TITLE
fix: 🐛restore 'raw_round_applications' asset

### DIFF
--- a/ggdp/assets.py
+++ b/ggdp/assets.py
@@ -102,7 +102,7 @@ def raw_round_votes() -> pd.DataFrame:
 
 @asset
 def raw_round_applications() -> pd.DataFrame:
-    applications = chain_file_aggregator("applications.json")
+    applications = round_file_aggregator("applications.json")
     applications['metadata'] = applications['metadata'].apply(json.dumps)
     return applications
 


### PR DESCRIPTION
Error in my previous PR caused partial failures during CI run, due to which `raw_round_applications` table no longer materializes. 

This should fix the regression caused by attempting to fetch `raw_round_applications.json` using  `chain_file_aggregator` instead of `round_file_aggregator`.
