### PR TITLE
Extend `rounds` model with `name` + other columns extracted from JSON

### DIFF
--- a/dbt/models/rounds.sql
+++ b/dbt/models/rounds.sql
@@ -23,6 +23,16 @@ renamed as (
         updatedAtBlock as updated_at_block,
         chainId as chain_id
     from source
+),
+
+extracted_metadata as (
+    select
+        *,
+        json_extract_path_text(metadata, 'name') as name,
+        json_extract_path_text(metadata, 'roundType') as round_type,
+        json_extract_path_text(metadata, 'programContractAddress') as program_address,
+        json_extract_path_text(metadata, '$.quadraticFundingConfig.sybilDefense')::boolean as sybil_defense        
+    from renamed
 )
 
-select * from renamed
+select * from extracted_metadata


### PR DESCRIPTION
`main.rounds` table is very nice I am trying to make it nicer by adding human-readable round `name` column + some other values extracted from JSON metadata column.

Tested changes locally by running `dagster -> dbt` steps to ensure model is indeed populating the table. 

Didn't test how this change interacts with later steps of Github CI so buyer beware.