### PR TITLE
Extend `round_applications` model with `recipient` + `signature`

### DIFF
--- a/dbt/models/round_applications.sql
+++ b/dbt/models/round_applications.sql
@@ -17,6 +17,14 @@ renamed as (
         statusUpdatedAtBlock as status_updated_at_block,
         statusSnapshots as status_snapshots
     from source
-)
+),
 
-select * from renamed
+extracted_metadata as (
+    select
+        *,
+        json_extract_path_text(metadata, 'signature') as signature,
+        lower(json_extract_path_text(metadata, '$.application.recipient')) as recipient   
+    from renamed
+)   
+    
+select * from extracted_metadata


### PR DESCRIPTION
`main.round_applications` table `metadata` column contains information that seems to be duplicated in other tables (`project`, `round`) so not much work to do here.

What we can learn is `recipient` which looks like actual address to which funds donated to given project will be sent during round and cryptographic `signature` for the application.

There is some interesting information in `$.application.answers` array present for each row but that is handled by separate PR #15 