### PR TITLE
Create `application_answers` dbt model

### DIFF
--- a/dbt/models/application_answers.sql
+++ b/dbt/models/application_answers.sql
@@ -1,0 +1,30 @@
+with  source as (
+        select metadata, chainid, roundid, projectid, id from {{ source("public", "raw_round_applications") }}
+    ),
+
+    renamed as (
+        select
+            unnest(
+                from_json(json_extract_path_text(source.metadata, '$.application.answers'), '["json"]')
+            ) as row_json,
+            chainid as chain_id,
+            roundid as round_id,
+            id as application_id,
+            projectid as project_id
+        from source
+    ),
+
+    extracted as (
+        select
+            json_extract_path_text(row_json, 'questionId') as question_id,
+            project_id,
+            application_id,
+            chain_id,
+            lower(round_id) as round_id,
+            json_extract_path_text(row_json, 'question') as question,
+            json_extract_path_text(row_json, 'type') as question_type,
+            json_extract_path_text(row_json, 'answer') as answer
+        from renamed
+    )
+
+select * from extracted where answer is not null  -- filters out encrypted and skipped answers


### PR DESCRIPTION
When applying to round applicants typically answer some questions. Questions and answers are stored in `metadata` column of `round_applications` table.

This model builds ` main.application_answers` table where each row contains `question + answer + question_type` triplets and all `id` information needed to recover who authored the answer for which round etc.

It could be more space efficient to have two separate tables `questions/answers` so we don't repeat question text for each row, but current way is easier to query. 
