### PR TITLE
Add sample Quarto OJS notebook

### DIFF
--- a/notebooks/client-side-query.qmd
+++ b/notebooks/client-side-query.qmd
@@ -1,0 +1,27 @@
+---
+title: "Client Side Query Test"
+format: html
+---
+
+```{ojs}
+cid = await FileAttachment("https://raw.githubusercontent.com/davidgasquez/gitcoin-grants-data-portal/main/data/IPFS_CID").text()
+url = "https://ipfs.filebase.io/ipfs/" + cid.trim()
+```
+
+```{ojs}
+ggdp = DuckDBClient.of()
+r = ggdp.query(`
+    select
+        *
+    from parquet_scan('${url}/round_votes.parquet')
+`)
+
+```
+
+```{ojs}
+viewof search = Inputs.search(r, "project_id")
+```
+
+```{ojs}
+Inputs.table(search)
+```

--- a/notebooks/sandbox.ipynb
+++ b/notebooks/sandbox.ipynb
@@ -19,7 +19,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Welcome to the Gitcoin Grants Data Portal. Your open source, serverless, and local-first Data Platform for Gitcoin Grants Data. With this data hub, we aim to improve data access and empower data scientists to conduct research and guide community driven analysis and decisions!"
+    "Welcome to the Gitcoin Grants Data Portal. Your open source, serverless, and local-first Data Platform for Gitcoin Grants Data. With this data hub, we aim to improve data access and empower data scientists to conduct research and guide community driven analysis and decisions!\n",
+    "\n",
+    "<a \n",
+    "    target=\"_blank\" \n",
+    "    href=\"https://colab.research.google.com/github/davidgasquez/gitcoin-grants-data-portal/blob/main/notebooks/sandbox.ipynb\"> \n",
+    "    <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
+    "</a>"
    ]
   },
   {


### PR DESCRIPTION
Adding a simple notebook to display how could people use the Parquet files from WASM. Also deployed [a demo site on IPFS](https://bafybeiaopdylc43rkyp7ptk6zpg3u5haxvici6kr4xtak6ehbczdc3tgsa.ipfs.cf-ipfs.com/)!

Opening the site will run an SQL query to the latest Parquet files on IPFS using WASM and then return all the data. You can filter on `project_id`.

![image](https://github.com/davidgasquez/gitcoin-grants-data-portal/assets/1682202/5532fdb5-f557-448f-8eae-a73a5fad562f)

It is very rought and not optimized at all. Basically doing a 40MB query. :see_no_evil: On the other hand, is running entirely on IPFS and your browser!
