### PR TITLE
Add 'chain_metadata' model family

### DIFF
--- a/dbt/models/chain_metadata.sql
+++ b/dbt/models/chain_metadata.sql
@@ -1,0 +1,20 @@
+with source as (
+    select * from {{ source('public', 'raw_chain_metadata') }}
+),
+
+renamed as (
+    select
+        name,
+        shortName as short_name,
+        infoURL as info_url,
+        chainId as chain_id,
+        networkId as network_id,
+        nativeCurrency as native_currency,
+        ens,
+        explorers,
+        rpc,
+        parent
+    from source
+)
+
+select * from renamed

--- a/dbt/models/sources.yml
+++ b/dbt/models/sources.yml
@@ -27,3 +27,7 @@ sources:
         meta:
           dagster:
             asset_key: ["raw_round_applications"]
+      - name: raw_chain_metadata
+        meta:
+          dagster:
+            asset_key: ["raw_chain_metadata"]


### PR DESCRIPTION
Current dataset contains a few places where `chain_id` is used. Reports may want to include links to chain-explorers or human readable name for any chain. 

This PR builds `chain_metadata` table with additional information about chains indexer is operating on (most notably: `name`, `native_currency`, `info_url`, `rpc`, `explorers` , `chain_id`, `network_id`).

To achieve this, two models were built:
1. `raw_chain_metadata` model loads data from `https://chainid.network/chains.json`.
2. `chain_metadata` model transforms table to match naming conventions 

As it stands `raw_chain_metadata` model depends on `raw_rounds`  to fetch list of interesting `chain_ids`. 