### PR TITLE
Add `dbt test` for address consistency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ run:
 dev:
 	@dagster dev -m ggdp
 
+test:
+	@cd dbt && dbt test
+
 preview:
 	@quarto preview portal
 

--- a/dbt/models/round_votes.sql
+++ b/dbt/models/round_votes.sql
@@ -12,8 +12,8 @@ renamed as (
         projectId as project_id,
         applicationId as application_id,
         lower(voter) as voter,
-        grantAddress as grant_address,
-        token,
+        lower(grantAddress) as grant_address,
+        lower(token) as token,
         amount,
         amountUSD as amount_usd,
         amountRoundToken as amount_round_token

--- a/dbt/models/rounds.sql
+++ b/dbt/models/rounds.sql
@@ -4,10 +4,10 @@ with source as (
 
 renamed as (
     select
-        id,
+        lower(id) as id,
         amountUSD as amount_usd,
         votes,
-        token,
+        lower(token) as token,
         matchAmount as match_amount,
         matchAmountUSD as match_amount_usd,
         uniqueContributors as unique_contributors,
@@ -30,7 +30,7 @@ extracted_metadata as (
         *,
         json_extract_path_text(metadata, 'name') as name,
         json_extract_path_text(metadata, 'roundType') as round_type,
-        json_extract_path_text(metadata, 'programContractAddress') as program_address,
+        lower(json_extract_path_text(metadata, 'programContractAddress')) as program_address,
         json_extract_path_text(metadata, '$.quadraticFundingConfig.sybilDefense')::boolean as sybil_defense
     from renamed
 )

--- a/dbt/models/schema.yml
+++ b/dbt/models/schema.yml
@@ -1,0 +1,36 @@
+version: 2
+
+models:
+
+
+  - name : passport_scores
+    columns:
+      - name: address
+        tests: ['is_address_lowercase']
+
+  - name: projects
+    columns:
+      - name: chain_id
+        tests: ['not_null']
+
+  - name : round_applications
+    columns:
+      - name: recipient
+        tests: ['is_address_lowercase']
+
+  - name : round_votes
+    columns:
+      - name: voter
+        tests: ['not_null', 'is_address_lowercase']
+      - name: grant_address
+        tests: ['not_null','is_address_lowercase']
+      - name: token
+        tests: ['is_address_lowercase']   
+  
+  - name : rounds
+    columns:
+      - name: program_address
+        tests: ['is_address_lowercase']
+      - name: id
+        tests: ['is_address_lowercase']
+    

--- a/dbt/tests/generic/is_address_lowercase.sql
+++ b/dbt/tests/generic/is_address_lowercase.sql
@@ -1,0 +1,8 @@
+{% test is_address_lowercase(model, column_name) %}
+
+select *
+    from {{ model }}
+    where {{ column_name }} is not null
+    and {{ column_name }} != lower({{ column_name }})
+
+{% endtest %}


### PR DESCRIPTION
Tests that make sure all addresses are stored in consistent, lowercase format. 

- added generic test `is_address_lowercase` which should be applied to every address
- added `make test` which runs `dbt test`
- started working on schema description

Second commit modifies the dbt models to make sure tests actually pass.

Interesting side-effect is that calling `make run` (or selectively materializing asset for which test exists) will actually run tests as the final step, even though I did not touch any configuration.