### PR TITLE
Add 'raw_allo_deployments' for use in downstream assets

### DIFF
--- a/ggdp/assets.py
+++ b/ggdp/assets.py
@@ -36,6 +36,11 @@ def read_json_with_retry(json_path):
     return pd.read_json(response.text)
 
 
+@retry(tries=8, delay=2, backoff=2, max_delay=10)
+def read_parquet_with_retry(path):
+    return pd.read_parquet(path)
+
+
 def round_file_aggregator(json_name):
     fs = HTTPFileSystem(simple_links=True)
     paths = fs.ls(ALLO_INDEXER_URL)
@@ -147,3 +152,16 @@ def raw_chain_metadata(raw_rounds: pd.DataFrame) -> pd.DataFrame:
     filtered_df = df[df.chainId.isin(interesting_chains)]
 
     return filtered_df
+
+
+@asset
+def raw_allo_deployments() -> pd.DataFrame:
+    """
+    Deployment address for all official allo contract deployments by Allo team, collected 07.01.24
+
+    Canonical source: https://github.com/allo-protocol/allo-contracts/blob/main/docs/CHAINS.md
+    """
+    ipfs_content = read_parquet_with_retry(
+        "https://cloudflare-ipfs.com/ipfs/QmWpnErRwVRLqdGsBC2J9NMngwzJtWErDZvf6wDqJ1ZVis"
+    )
+    return ipfs_content

--- a/ggdp/assets.py
+++ b/ggdp/assets.py
@@ -160,6 +160,7 @@ def raw_allo_deployments() -> pd.DataFrame:
     Deployment address for all official allo contract deployments by Allo team, collected 07.01.24
 
     Canonical source: https://github.com/allo-protocol/allo-contracts/blob/main/docs/CHAINS.md
+    Ingestion logic: https://gist.github.com/DistributedDoge/57e39c3e5cc207fcafdf4d377562ec33
     """
     ipfs_content = read_parquet_with_retry(
         "https://cloudflare-ipfs.com/ipfs/QmWpnErRwVRLqdGsBC2J9NMngwzJtWErDZvf6wDqJ1ZVis"


### PR DESCRIPTION
Adds new `static` (based on pulling pre-processed '.parquet' from IPFS) asset with contract address for each official Allo contract. 

Main use of this data is feeding downstream `cryo/covalent` assets, which should much more interesting.

Original [ingestion logic](https://gist.github.com/DistributedDoge/57e39c3e5cc207fcafdf4d377562ec33) is dependent on formatting of markdown document which feels very brittle thing to include, hence why I opted for the `ipfs-fetch` strategy.

- Note that after merge schema displayed in `catalog` on the portal would not reflect new asset, but this isn't a priority to me for now.  

EDIT: Checked CI logs, looks ready to merge