### PR TITLE
feat: ⚡️ add job for dune upload

### DIFF
--- a/ggdp/ops.py
+++ b/ggdp/ops.py
@@ -1,0 +1,48 @@
+import io
+import json
+import os
+
+import pandas as pd
+import requests as rq
+
+from .assets import raw_allo_deployments
+from dagster import op, job, OpExecutionContext
+
+
+@op()
+def tiny_upload_to_dune(context: OpExecutionContext, data: pd.DataFrame) -> None:
+    """
+    Upload select dataframe to dune using API, needs DUNE_API_KEY envar to succeeed.
+    """
+
+    DUNE_KEY = os.getenv("DUNE_API_KEY")
+    if DUNE_KEY is None:
+        raise ValueError("DUNE_API_KEY envar not set, cannot upload")
+
+    file_buffer = io.StringIO()
+    data.to_csv(file_buffer, index=False)
+    file_buffer.seek(0)
+    csv_content = file_buffer.getvalue()
+
+    upload_payload = json.dumps(
+        {"table_name": "allo_contract_deployments", "data": csv_content}
+    )
+
+    response = rq.post(
+        "https://api.dune.com/api/v1/table/upload/csv",
+        headers={"X-Dune-Api-Key": DUNE_KEY},
+        data=upload_payload,
+    )
+    context.log.info(
+        f"new data uploaded to dune, result:{str(response.status_code)} | {str(response.text)}"
+    )
+
+    response.raise_for_status()
+
+
+@job
+def refresh_dune():
+    """
+    Refresh public dune dataset by materializing `raw_allo_deployments` and uploading new version.
+    """
+    tiny_upload_to_dune(data=raw_allo_deployments())


### PR DESCRIPTION
This PR builds an `op` and three `jobs` to see if we can play nicely with new dagster primitives and address #38. 

It does not modify existing workflow in any way (or at least I hope it doesn't), but allows us to use new CLI commands:
```
dagster job list -m ggdp
dagster job execute -m ggdp -j build_indexer_assets
```
For dagster UI navigate to `Overview` =>`Jobs` to see new additions:

- `build all` materializes everything
- `build_indexer_assets` builds assets provided by indexer, except votes for fast testing
- `refresh dune`  materializes an asset and then uses **op** to upload said asset onto Dune.

To succeed job needs envar DUNE_API_KEY to be set first. 

![image](https://github.com/davidgasquez/gitcoin-grants-data-portal/assets/49067954/95ce902b-7ba1-471b-a200-762e44346f38)

Once uploaded, dataset becomes accessible [like so](https://dune.com/queries/3339754).