### PR TITLE
ci: 👷 add step times to CI summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,21 @@ jobs:
 
     - name: Run
       run: |
-        make run
+        set -o pipefail
+        make run 2>&1 | tee dagster.log
+
+    - name: Extract Step Execution time from logs
+      run: |
+        echo "Dagster step timings:" >> $GITHUB_STEP_SUMMARY
+        echo "Step Name | Execution Time" >> $GITHUB_STEP_SUMMARY
+        echo "-----------|----------------" >> $GITHUB_STEP_SUMMARY
+        while IFS= read -r line; do
+          if [[ $line == *"STEP_SUCCESS"* ]]; then
+            step_name=$(echo "$line" | awk -F' - ' '{print $7}')
+            exec_time=$(echo "$line" | awk -F' - ' '{split($9,a," "); print a[7]}')
+            echo "$step_name | $exec_time" >> $GITHUB_STEP_SUMMARY
+          fi
+        done < dagster.log
 
     - name: Export Database and Log File Sizes
       run: |


### PR DESCRIPTION
Adds a single step to  `CI` that parses `make run` logs and builds dagster step timing table, displayed as part of Github run summary.

I find this handy for checking which assets are fast and which slow to build during development. 

EDIT: Models produced from `dbt` assets are counted as part of single step looking like this `run_dbt_7d08a`.

![image](https://github.com/davidgasquez/gitcoin-grants-data-portal/assets/49067954/a8422dec-840f-457d-8e58-d3c7956b4f81)
