### PR TITLE
ci: 👷 swap branch used by CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        ref: refs/pull/${{ github.event.pull_request.number }}/merge
+
 
     - name: Set up Python
       uses: actions/setup-python@v5


### PR DESCRIPTION
Follow-up to PR #49 that restores `CI` to full functionality fixing #47.

When `make run` is being triggered we now need to specify it has to run on `pr-branch (after merge)` not on `main branch (before merge)`. 

Tested on my fork, ready to merge.