### PR TITLE
feat: ✨add Giveth projects from GraphQL API

### DIFF
--- a/dbt/models/giveth_projects.sql
+++ b/dbt/models/giveth_projects.sql
@@ -1,0 +1,13 @@
+with source as (
+    select * from {{ source('public', 'raw_giveth_projects') }}
+),
+
+renamed as (
+    select
+        title,
+        totalDonations as total_donations,
+        totalTraceDonations as total_trace_donations
+    from source
+)
+
+select * from renamed

--- a/dbt/models/sources.yml
+++ b/dbt/models/sources.yml
@@ -31,3 +31,7 @@ sources:
         meta:
           dagster:
             asset_key: ["raw_chain_metadata"]
+      - name: raw_giveth_projects
+        meta:
+          dagster:
+            asset_key: ["raw_giveth_projects"]


### PR DESCRIPTION
Introduces `giveth_projects` dbt-asset listing all ~2.5k projects currently active on Giveth + total donation stats for each.

At this time, model has only three columns, but should be very easy to extend. 

Source: https://mainnet.serve.giveth.io/graphql

Ready to merge - pls squash before merging for nice PR message. 