### PR TITLE
feat: ⚡️ add 'raw_discourse_categories' asset

### DIFF
--- a/ggdp/assets.py
+++ b/ggdp/assets.py
@@ -239,3 +239,30 @@ def raw_giveth_projects():
     giveth = pd.DataFrame(all_projects)
     giveth.convert_dtypes()
     return giveth
+
+
+@asset
+def raw_discourse_categories():
+    """
+    Listing of categories from "Discourse" of various communities.
+
+    Use 'source' column to group categories by Discourse instance.
+    """
+    forums = {
+        "Gitcoin": "https://gov.gitcoin.co",
+        "Giveth": "https://forum.giveth.io",
+        "Arbitrum": "https://forum.arbitrum.foundation",
+        "Optimism": "https://gov.optimism.io/",
+    }
+
+    data = []
+    for community, forum_address in forums.items():
+        catalog = read_json_with_retry(f"{forum_address}/categories.json")
+        catalog = catalog["category_list"]["categories"]
+        for category in catalog:
+            category["source"] = community
+        data.extend(catalog)
+
+    discourse_df = pd.DataFrame(data)
+    discourse_df = discourse_df.convert_dtypes()
+    return discourse_df


### PR DESCRIPTION
Creates a single asset that builds a table, where each row is a Discourse category like say "Proposals" or "Grants" on some Discourse instance. Not all Discourse instances give us listings of topics, but all of them yield stats (e.g. number of posts in category)

- Currently scans `/categories.json` endpoint for `Giveth, Gitcoin, Arbitrum, Optimism` , more forums can be added
- Use `source` column to identify Discourse from which specific category was taken.


Further work will be:

-  add `dbt` model 
- build downstream model that fetches topic bodies for interesting categories for each forum (e.g. fetch PROPOSALS/GRANTS from both Gitcoin and Giveth)

I think data is interesting as-is and model is stable so it should be ready to merge!