### PR TITLE
ci: 👷 add `link_check.yml` Github Action

### DIFF
--- a/.github/workflows/link_check.yml
+++ b/.github/workflows/link_check.yml
@@ -1,0 +1,19 @@
+name: Check Portal for broken links
+on: 
+  schedule:
+    - cron: "10 10 * * 1"
+  workflow_dispatch: # allow manual trigger
+jobs:
+  crawl_for_broken_links:
+    runs-on: ubuntu-latest
+    name: Broken-Links-Crawler
+    steps:
+    - name: Checking links
+      uses: ScholliYT/Broken-Links-Crawler-Action@v3
+      with:
+        website_url: 'https://davidgasquez.github.io/gitcoin-grants-data-portal/'
+        verbose: 'true'
+        exclude_url_contained: 'twitter'
+        max_retry_time: 30
+        max_retries: 5
+        max_depth: 1


### PR DESCRIPTION
Adds standalone workflow (partially solving #65)  that crawls public version of Portal website and reports any broken links.

- If broken links are encountered workflow will FAIL and broken link would be listed in action logs.
- Action is set to trigger 10 minutes after weekly portal update on Monday.
- I have to ignore links to twitter, as Elon doesn't accept bots.