### PR TITLE
feat: ✨ create `hypercert_claims` assets

### DIFF
--- a/dbt/models/hypercert_claims.sql
+++ b/dbt/models/hypercert_claims.sql
@@ -1,0 +1,16 @@
+with source as (
+    select * from {{ source('public', 'raw_hypercert_claims') }}
+),
+
+renamed as (
+    select
+        id,
+        tokenID as token_id,
+        lower(contract) as contract,
+        uri as uri,
+        CAST(totalUnits AS BIGINT) as total_units,
+        lower(creator) as creator
+    from source
+)
+
+select * from renamed

--- a/dbt/models/hypercert_claims.sql
+++ b/dbt/models/hypercert_claims.sql
@@ -7,7 +7,7 @@ renamed as (
         id,
         tokenID as token_id,
         lower(contract) as contract,
-        uri as uri,
+        uri as ipfs_cid,
         CAST(totalUnits AS BIGINT) as total_units,
         lower(creator) as creator
     from source

--- a/dbt/models/sources.yml
+++ b/dbt/models/sources.yml
@@ -43,3 +43,7 @@ sources:
         meta:
           dagster:
             asset_key: ["raw_giveth_projects"]
+      - name: raw_hypercert_claims
+        meta:
+          dagster:
+            asset_key: ["raw_hypercert_claims"]

--- a/ggdp/assets/other.py
+++ b/ggdp/assets/other.py
@@ -130,3 +130,59 @@ def raw_gitcoin_passport_scores() -> pd.DataFrame:
     )
 
     return df[df["address"].str.startswith("0x")]
+
+
+@retry(
+    stop=stop_after_attempt(8),
+    wait=wait_exponential(multiplier=1, min=4, max=10),
+)
+def get_hypercerts(gql_endpoint, creator_addresses):
+    query = """
+    query ClaimsQuery($creatorAddresses: [String]!) {
+      claims(first: 1000, where: {creator_in: $creatorAddresses}) {
+        id
+        creation
+        tokenID
+        contract
+        uri
+        totalUnits
+        creator
+      }
+    }
+    """
+    payload = {
+        "query": query,
+        "variables": {
+            "creatorAddresses": creator_addresses
+        }
+    }
+
+    response = requests.post(gql_endpoint, json=payload)
+    response.raise_for_status()
+    return response.json()['data']['claims']
+
+
+@asset
+def raw_hypercert_claims(raw_allo_projects) -> pd.DataFrame:
+    """
+    Listing of hypercerts created by Allo Grantees
+
+    Source: https://thegraph.com/hosted-service/subgraph/hypercerts-admin/hypercerts-optimism-mainnet
+    """
+    HYPERCERTS_ENDPOINT = "https://api.thegraph.com/subgraphs/name/hypercerts-admin/hypercerts-optimism-mainnet"
+    grantees = list(raw_allo_projects.createdByAddress.str.lower().unique())
+
+    all_certs = []
+
+    window_size = 1000
+    for start_index in range(0, len(grantees), window_size):
+        window_creators = grantees[start_index:start_index+window_size]
+        result = get_hypercerts(HYPERCERTS_ENDPOINT, window_creators)
+        all_certs.extend(result)
+
+    certs_df = pd.DataFrame(all_certs)
+    certs_df.uri = certs_df.uri.str.replace('ipfs://','')
+
+    certs_df = certs_df.convert_dtypes()
+
+    return certs_df


### PR DESCRIPTION
This adds dbt model `hypercert_claims` and corresponding `raw_` asset which lists Hypercerts created by Gitcoin grantees. 

Thanks to this asset:

- We know `creator`, `total_units`, `id` of hypecert created by any grantee (on Optimism).
-  `uri` points to IPFS hash with useful metadata like actual title or image of hypecert.

Endpoint:

https://thegraph.com/hosted-service/subgraph/hypercerts-admin/hypercerts-optimism-mainnet