### PR TITLE
feat: ✨ create `karmahq_details` model

### DIFF
--- a/dbt/models/karmahq_details.sql
+++ b/dbt/models/karmahq_details.sql
@@ -1,0 +1,16 @@
+with source as (
+    select * from {{ source('public', 'raw_karmahq_attestations') }}
+),
+
+renamed as (
+    select
+        lower(attester) as attester,
+        lower(recipient) as recipient,
+        isOffchain as is_offchain,
+        decodedDataJson as json,
+        JSON_EXTRACT(decodedDataJson->>'$[0].value.value', '$.hash') as ipfs_cid,
+        JSON_EXTRACT(decodedDataJson->>'$[0].value.value', '$.title') as title
+    from source
+)
+
+select * from renamed

--- a/dbt/models/sources.yml
+++ b/dbt/models/sources.yml
@@ -47,3 +47,7 @@ sources:
         meta:
           dagster:
             asset_key: ["raw_hypercert_claims"]
+      - name: raw_karmahq_attestations
+        meta:
+          dagster:
+            asset_key: ["raw_karmahq_attestations"]


### PR DESCRIPTION
This creates a model that listens to update details published by `KarmaHQ` using `Ethereum Attestation Service` as per #68 .

Some update details are served directly inside `json` and some as `ipfs_cid` pointer to remote content. 

Next step would be to create downstream models for each Entity (e.g. `milestone` vs `profile`) to clean this up.

For now it works as intended telling us which Gitcoin Grantees use KarmaGap and giving us all project titles, so I think it can be merged as-is.