### PR TITLE
chore: 🦆install duckdb cli [no ci]

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,9 @@
     "dockerfile": "../Dockerfile",
     "context": ".."
   },
+  "features": {
+    "ghcr.io/eitsupi/devcontainer-features/duckdb-cli:1":{}
+  },
   "customizations": {
     "vscode": {
       "settings": {


### PR DESCRIPTION
`duckdb` command is now working inside devcontainer, installed via [features](https://containers.dev/features). 

I find the [CLI](https://duckdb.org/docs/api/cli/overview.html) useful for tweaking `dbt` models from within Github Codespace. 