### PR TITLE
chore: 🦆install harlequin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ setup:
 	uv venv
 	uv pip install -U -e .[dev]
 	. .venv/bin/activate
+	pipx install harlequin
+
+sql:
+	@harlequin "./data/local.duckdb"
 
 test:
 	@cd dbt && dbt test


### PR DESCRIPTION
As suggested in #79, `harlequin` is handy enough, and ships with `duckdb`  out of box.

`make setup` will now install `harlequin`.
`make sql` will open harlequin pointed at  `data/local.duckdb` file.